### PR TITLE
fix: cadvisor can pickup oom events

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -58,10 +58,15 @@ spec:
         - name: disk
           mountPath: /dev/disk
           readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
         ports:
         - name: http
           containerPort: 48080
           protocol: TCP
+        securityContext:
+          privileged: true
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       volumes:
@@ -80,3 +85,6 @@ spec:
       - name: disk
         hostPath:
           path: /dev/disk
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg

--- a/overlays/non-privileged/cadvisor/cadvisor.DaemonSet.yaml
+++ b/overlays/non-privileged/cadvisor/cadvisor.DaemonSet.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cadvisor
+        volumeMounts:
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
+          $patch: delete
+        securityContext:
+          privileged: null
+      volumes:
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+        $patch: delete

--- a/overlays/non-privileged/kustomization.yaml
+++ b/overlays/non-privileged/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - frontend/sourcegraph-frontend.RoleBinding.yaml
   - prometheus/prometheus.RoleBinding.yaml
 patchesStrategicMerge:
+  - cadvisor/cadvisor.DaemonSet.yaml
   - codeintel-db/codeintel-db.Deployment.yaml
   - codeinsights-db/codeinsights-db.Deployment.yaml
   - frontend/sourcegraph-frontend.Deployment.yaml


### PR DESCRIPTION
<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
